### PR TITLE
Remove mount options for Azure

### DIFF
--- a/charts/besu/templates/storage.yml
+++ b/charts/besu/templates/storage.yml
@@ -22,12 +22,6 @@ parameters:
 {{- else if eq .Values.global.provider "azure" }}
 allowVolumeExpansion: {{ .Values.storage.allowVolumeExpansion }}
 provisioner: disk.csi.azure.com
-mountOptions:
-  - dir_mode=0755
-  - file_mode=0755
-  - uid=0
-  - gid=0
-  - mfsymlinks
 parameters:
   {{- with .Values.storage.parameters }}
   {{- toYaml . | nindent 2 }}


### PR DESCRIPTION
Having mount options for the Azure storage class would not create the pods. Mount options seems to be required for the Azure files https://learn.microsoft.com/en-us/troubleshoot/azure/azure-kubernetes/storage/mountoptions-settings-azure-files. Documentation does not mention about mount options for Azure disks https://learn.microsoft.com/en-us/azure/aks/azure-disk-csi#create-a-custom-storage-class. Removed the mount options from storageClass