### PR TITLE
Support for podTargetLabels in service monitor

### DIFF
--- a/charts/ethereum-helm-charts/Chart.yaml
+++ b/charts/ethereum-helm-charts/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v2
 name: ethnode
 description: An Ethereum Helm chart for Kubernetes
 type: application
-version: 0.1.1
+version: 0.1.2
 
 dependencies:
   - name: elc
-    version: "~0.0.1"
+    version: "0.0.2"
   - name: clc
-    version: "~0.0.1"
+    version: "0.0.2"

--- a/charts/ethereum-helm-charts/charts/clc/Chart.yaml
+++ b/charts/ethereum-helm-charts/charts/clc/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: clc
 description: An clc Helm chart for Kubernetes
 type: application
-version: 0.0.1
+version: 0.0.2

--- a/charts/ethereum-helm-charts/charts/clc/templates/service.yaml
+++ b/charts/ethereum-helm-charts/charts/clc/templates/service.yaml
@@ -48,3 +48,8 @@ spec:
     path: /metrics
     scheme: http
     honorLabels: true
+  {{- with .Values.service.monitor }}
+  {{- if and (.podTargetLabels) (eq (kindOf .podTargetLabels) "slice" ) }}
+  podTargetLabels: {{ .podTargetLabels }}
+  {{- end }}
+  {{- end }}

--- a/charts/ethereum-helm-charts/charts/clc/values.yaml
+++ b/charts/ethereum-helm-charts/charts/clc/values.yaml
@@ -49,6 +49,9 @@ service:
       port: 8008
       targetPort: clc-metrics
       protocol: TCP
+ # Configure pods labels that need to be added as Prometheus labels
+ # monitor:
+ #   podTargetLabels: []
 
 resources:
   cpuLimit: 4

--- a/charts/ethereum-helm-charts/charts/elc/Chart.yaml
+++ b/charts/ethereum-helm-charts/charts/elc/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: elc
 description: An elc Helm chart for Kubernetes
 type: application
-version: 0.0.1
+version: 0.0.2

--- a/charts/ethereum-helm-charts/charts/elc/templates/service.yaml
+++ b/charts/ethereum-helm-charts/charts/elc/templates/service.yaml
@@ -50,3 +50,8 @@ spec:
     path: /metrics
     scheme: http
     honorLabels: true
+  {{- with .Values.service.monitor }}
+  {{- if and (.podTargetLabels) (eq (kindOf .podTargetLabels) "slice" ) }}
+  podTargetLabels: {{ .podTargetLabels }}
+  {{- end }}
+  {{- end }}

--- a/charts/ethereum-helm-charts/charts/elc/values.yaml
+++ b/charts/ethereum-helm-charts/charts/elc/values.yaml
@@ -56,6 +56,9 @@ service:
       port: 8551
       targetPort: elc-engine
       protocol: TCP
+ # Configure pods labels that need to be added as Prometheus labels
+ # monitor:
+ #   podTargetLabels: []
 
 resources:
   cpuLimit: 4


### PR DESCRIPTION
Service monitor for elc and clc now support configuring podTargetLabels which allows adding specific pod labels in a service as Prometheus labels